### PR TITLE
FIX: undefined reference to <math.h>

### DIFF
--- a/hash-table/Makefile
+++ b/hash-table/Makefile
@@ -3,11 +3,11 @@
 CFLAGS = -Wall -Werror -Wextra -g
 
 build: clean
-	${CC} ${CFLAGS} -shared -o build/hash_table.so -fPIC src/hash_table.c src/xmalloc.c src/prime.c
+	${CC} ${CFLAGS} -shared -o build/hash_table.so -fPIC src/hash_table.c src/xmalloc.c src/prime.c -lm
 
 build-test: clean
-	${CC} ${CFLAGS} -o build/hash_table_test src/hash_table.c test/hash_table_test.c src/xmalloc.c src/prime.c
-	${CC} ${CFLAGS} -o build/prime_test test/prime_test.c src/prime.c
+	${CC} ${CFLAGS} -o build/hash_table_test src/hash_table.c test/hash_table_test.c src/xmalloc.c src/prime.c -lm
+	${CC} ${CFLAGS} -o build/prime_test test/prime_test.c src/prime.c -lm
 
 clean:
 	rm -rf build/


### PR DESCRIPTION
This PR fix the following bug I found:
`make test` on Ubuntu 20.04(VM on Macbook air M1) failed:
```
rm -rf build/
mkdir -p build/
make -C analytics clean
make[1]: Entering directory '/home/parallels/tmp/algorithms-and-data-structures/hash-table/analytics'
rm -rf __pycache__
rm -f *.pyc
rm -f *.html
make[1]: Leaving directory '/home/parallels/tmp/algorithms-and-data-structures/hash-table/analytics'
cc -Wall -Werror -Wextra -g -o build/hash_table_test src/hash_table.c test/hash_table_test.c src/xmalloc.c src/prime.c
/usr/bin/ld: /tmp/ccFy1wsN.o: in function `ht_generic_hash':
/home/parallels/tmp/algorithms-and-data-structures/hash-table/src/hash_table.c:124: undefined reference to `pow'
/usr/bin/ld: /tmp/ccHkngkO.o: in function `is_prime':
/home/parallels/tmp/algorithms-and-data-structures/hash-table/src/prime.c:18: undefined reference to `sqrt'
/usr/bin/ld: /home/parallels/tmp/algorithms-and-data-structures/hash-table/src/prime.c:18: undefined reference to `floor'
collect2: error: ld returned 1 exit status
make: *** [Makefile:9: build-test] Error 1
```